### PR TITLE
Bug Fix for Table search

### DIFF
--- a/processLogMavens.py
+++ b/processLogMavens.py
@@ -501,7 +501,7 @@ else:
                                    DATETIME: handTime,
                                    TEXT: ''}
             elif (handNumber is not None):
-                table = re.search("Table: (.*)$", line)
+                table = re.search("^Table: (.*)$", line)
                 if (table != None):
                     tableName = table.group(1)
                     if (not tableName in tables):


### PR DESCRIPTION
If a user name actually ends in "Table:" then anytime they chat, it causes the script to error out (e.g., username = FinalTable). So, changed to search for lines that only start with "Table:" to separate out different tables.